### PR TITLE
Add job search UI form and open to jobs page

### DIFF
--- a/hacker-news-jobs/public/manifest.json
+++ b/hacker-news-jobs/public/manifest.json
@@ -12,6 +12,9 @@
   },
   "manifest_version": 3,
   "version": "1.0",
+  "permissions": [
+    "tabs"
+  ],
   "host_permissions": [
     "https://news.ycombinator.com/*"
   ],

--- a/hacker-news-jobs/src/chrome/content.ts
+++ b/hacker-news-jobs/src/chrome/content.ts
@@ -1,4 +1,4 @@
-import { ChromeMessage, Sender } from "../types";
+import { ChromeMessage, MessageType } from "../types";
 import HackerNews from './hn-api';
 import HackerNewsItem from './hn-api';
 
@@ -29,40 +29,29 @@ async function getComments(storyId: number, truncate: boolean) {
 
 const messagesFromReactAppListener = (
     message: ChromeMessage,
-    sender: chrome.runtime.MessageSender,
-    response: (message?: any) => void
+    sender: chrome.runtime.MessageSender
 ) => {
+    // Updating DOM to prove that message is received after loading new tab
+    // console.log only shows messages if console is open at the time
+    document.querySelectorAll('.titlelink').forEach(el => {
+        el.setAttribute("style", "color: red");
+    });
+
     console.log('[content.js]. Message received', {
         message,
         sender,
     })
 
-    if (
-        sender.id === chrome.runtime.id &&
-        message.from === Sender.React &&
-        message.message === 'Hello from React') {
-        document.querySelectorAll('.titlelink').forEach(el => {
-            el.setAttribute("style", "color: red");
-        });
-    }
-    else if (
-        sender.id === chrome.runtime.id &&
-        message.from === Sender.React &&
-        message.message === 'APITest') {
-
-        // HackerNews.getStories(HackerNews.TYPE_TOP, 0, 5)
-        //     .then((stories: any) => {
-        //         let i = 1;
-        //         stories.forEach((story: any) => console.log(`${i++}. ${story.title} [${story.score}] (${story.url})}`))
-        //     });
-
-        const nov2021WhoIsHiringId = 29067493
-        // TRUNCATE kidIds for testing
-        const truncate = true
-        getComments(nov2021WhoIsHiringId, truncate)
-            .then((jobPostings) => {
-                console.log(jobPostings)
-            })
+    if (message.messageType == MessageType.JobSearch) {
+        const storyParams = new URLSearchParams(window.location.search)
+        const storyId = storyParams.get('id');
+        if (storyId) {
+            const truncate = true
+            getComments(parseInt(storyId, 10), truncate)
+                .then((jobPostings) => {
+                    console.log(jobPostings)
+                })
+        }
     }
 }
 

--- a/hacker-news-jobs/src/chrome/content.ts
+++ b/hacker-news-jobs/src/chrome/content.ts
@@ -31,12 +31,6 @@ const messagesFromReactAppListener = (
     message: ChromeMessage,
     sender: chrome.runtime.MessageSender
 ) => {
-    // Updating DOM to prove that message is received after loading new tab
-    // console.log only shows messages if console is open at the time
-    document.querySelectorAll('.titlelink').forEach(el => {
-        el.setAttribute("style", "color: red");
-    });
-
     console.log('[content.js]. Message received', {
         message,
         sender,

--- a/hacker-news-jobs/src/chrome/hn-api.ts
+++ b/hacker-news-jobs/src/chrome/hn-api.ts
@@ -68,7 +68,7 @@ export interface HackerNewsUser {
     /** The user's optional self-description. HTML. */
     about: string,
     /** List of the user's stories, polls and comments. */
-    submitted: Array<string>,
+    submitted: Array<number>,
 }
 
 export default abstract class HackerNews {

--- a/hacker-news-jobs/src/chrome/hn-api.ts
+++ b/hacker-news-jobs/src/chrome/hn-api.ts
@@ -4,6 +4,10 @@ const fetch = require('node-fetch');
 
 const apiUrl = 'https://hacker-news.firebaseio.com/v0/';
 
+const baseHackerNewsPage = 'https://news.ycombinator.com';
+
+const whoIsHiringUser = 'whoishiring';
+
 /** Unique ID of a Hacker News item, positive integer */
 export type HackerNewsItemId = number;
 /** Unique ID of a Hacker News user, alphanumeric */
@@ -64,7 +68,7 @@ export interface HackerNewsUser {
     /** The user's optional self-description. HTML. */
     about: string,
     /** List of the user's stories, polls and comments. */
-    submitted: number,
+    submitted: Array<string>,
 }
 
 export default abstract class HackerNews {
@@ -83,8 +87,8 @@ export default abstract class HackerNews {
      */
     public static getItem(item: HackerNewsItemId): Promise<HackerNewsItem | null> {
         return fetch(`${apiUrl}/item/${item}.json`)
-            .then((res:any) => res.json())
-            .then((resjson:any) => resjson as HackerNewsItem);
+            .then((res: any) => res.json())
+            .then((resjson: any) => resjson as HackerNewsItem);
     }
 
     /**
@@ -93,8 +97,8 @@ export default abstract class HackerNews {
      */
     public static getUser(userId: HackerNewsUserId): Promise<HackerNewsUser | null> {
         return fetch(`${apiUrl}/user/${userId}.json`)
-            .then((res:any) => res.json())
-            .then((resjson:any) => resjson as HackerNewsUser);
+            .then((res: any) => res.json())
+            .then((resjson: any) => resjson as HackerNewsUser);
     }
 
     /**
@@ -103,8 +107,8 @@ export default abstract class HackerNews {
      */
     public static getMaxItemId(): Promise<HackerNewsItemId> {
         return fetch(`${apiUrl}/maxitem.json`)
-            .then((res:any) => res.json())
-            .then((resjson:any) => resjson as HackerNewsItemId);
+            .then((res: any) => res.json())
+            .then((resjson: any) => resjson as HackerNewsItemId);
     };
 
     /**
@@ -126,7 +130,7 @@ export default abstract class HackerNews {
 
     /**
      * Get stories
-     * @param offset offset, with 0 being the newest story 
+     * @param offset offset, with 0 being the newest story
      * @param amount Default: 10, amount of stories to return from offset on.
      * @returns Promise which resolves with an array of {@link HackerNewsItem}
      */
@@ -144,7 +148,7 @@ export default abstract class HackerNews {
 
     /**
      * Get stories
-     * @param offset offset, with 0 being the newest story 
+     * @param offset offset, with 0 being the newest story
      * @param amount Default: 10, amount of stories to return from offset on.
      * @returns Promise which resolves with an array of {@link HackerNewsItem}
      */
@@ -162,7 +166,7 @@ export default abstract class HackerNews {
 
     /**
      * Get stories
-     * @param offset offset, with 0 being the newest story 
+     * @param offset offset, with 0 being the newest story
      * @param amount Default: 10, amount of stories to return from offset on.
      * @returns Promise which resolves with an array of {@link HackerNewsItem}
      */
@@ -180,7 +184,7 @@ export default abstract class HackerNews {
 
     /**
      * Get stories
-     * @param offset offset, with 0 being the newest story 
+     * @param offset offset, with 0 being the newest story
      * @param amount Default: 10, amount of stories to return from offset on.
      * @returns Promise which resolves with an array of {@link HackerNewsItem}
      */
@@ -198,7 +202,7 @@ export default abstract class HackerNews {
 
     /**
      * Get stories
-     * @param offset offset, with 0 being the newest story 
+     * @param offset offset, with 0 being the newest story
      * @param amount Default: 10, amount of stories to return from offset on.
      * @returns Promise which resolves with an array of {@link HackerNewsItem}
      */
@@ -216,7 +220,7 @@ export default abstract class HackerNews {
 
     /**
      * Get stories
-     * @param offset offset, with 0 being the newest story 
+     * @param offset offset, with 0 being the newest story
      * @param amount Default: 10, amount of stories to return from offset on.
      * @returns Promise which resolves with an array of {@link HackerNewsItem}
      */
@@ -230,8 +234,8 @@ export default abstract class HackerNews {
      */
     public static getUpdates(): Promise<{ items: HackerNewsItemId[], profiles: HackerNewsUserId[]; }> {
         return fetch(`${apiUrl}/updates.json`)
-            .then((res:any) => res.json())
-            .then((resjson:any) => resjson as { items: HackerNewsItemId[], profiles: HackerNewsUserId[]; });
+            .then((res: any) => res.json())
+            .then((resjson: any) => resjson as { items: HackerNewsItemId[], profiles: HackerNewsUserId[]; });
     };
 
     /**
@@ -241,8 +245,8 @@ export default abstract class HackerNews {
      */
     public static getStoryIds(type: HackerNewsStoryType): Promise<HackerNewsItemId[]> {
         return fetch(`${apiUrl}/${type}stories.json`)
-            .then((res:any) => res.json())
-            .then((resjson:any) => resjson as HackerNewsItemId[]);
+            .then((res: any) => res.json())
+            .then((resjson: any) => resjson as HackerNewsItemId[]);
     }
 
     /**
@@ -258,5 +262,24 @@ export default abstract class HackerNews {
                 if (amount) storyIds = storyIds.slice(Math.min(offset, storyIds.length - 1), Math.min(offset + amount, storyIds.length - 1));
                 return Promise.all(storyIds.map(storyId => this.getItem(storyId) as unknown as HackerNewsItem));
             });
+    }
+
+    /**
+     * Identify the url of the latest whoishiring post
+     * @returns The latest jobs url
+     */
+    public static getLatestJobsPage(): Promise<string> {
+        return this.getUser(whoIsHiringUser)
+            .then((profile: HackerNewsUser | null) => {
+                if (profile) {
+                    if (profile.submitted.length > 0) {
+                        let latestStoryId = profile.submitted[0];
+                        if (latestStoryId) {
+                            return `${baseHackerNewsPage}/item?id=${latestStoryId}`;
+                        }
+                    }
+                }
+                return '';
+            })
     }
 }

--- a/hacker-news-jobs/src/types.ts
+++ b/hacker-news-jobs/src/types.ts
@@ -3,7 +3,12 @@ export enum Sender {
     Content
 }
 
+export enum MessageType {
+    JobSearch
+}
+
 export interface ChromeMessage {
     from: Sender,
-    message: any
+    messageType: MessageType,
+    message: string
 }


### PR DESCRIPTION
Updates the extension to create a "Job Search" form. If the user is not on the correct jobs Hacker News page, then it will open a new tab, send a job query message with a query string, then switch the active tab to the opened page. 

If the user is already on the correct page, then it just sends the search query in a message to the content script.

Added a method to the HackerNews api functions to fetch the latest jobs page by searching submissions from the `whoishiring` user.