### PR TITLE
Cache postings fetch and only fetch based on what is on page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ To test the search results, we used the following queries and measured precision
 * devops infrastructure
 
 We documented our findings [here](https://docs.google.com/spreadsheets/d/1-DkfujZc6qVkG42upE_-XXvm2gTSTwqhBM8Nog3A8jg/edit?usp=sharing). That Google Sheet is accessible using UIUC logins. We noted the original order of the results against the resulting search order as well. Most of the results pulled from postings far below the default Hacker News ranking.
+
+To facilitate the testing, we log the search results along with their original order in the console. Open the Chrome developer console and look for the log output "Ranked output from search." The objects printed after that are the search results and include their original order.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ The `.ts` file extension means a file is [TypeScript](https://www.typescriptlang
 [HN API guide](https://github.com/HackerNews/API)
 
 [HN API framework code](https://github.com/karpour/hackernews-api-ts)
+
+## Testing
+
+To test the search results, we used the following queries and measured precision @ 10 recommendations:
+
+* frontend javascript
+* data science python
+* devops infrastructure
+
+We documented our findings [here](https://docs.google.com/spreadsheets/d/1-DkfujZc6qVkG42upE_-XXvm2gTSTwqhBM8Nog3A8jg/edit?usp=sharing). That Google Sheet is accessible using UIUC logins. We noted the original order of the results against the resulting search order as well. Most of the results pulled from postings far below the default Hacker News ranking.

--- a/hacker-news-jobs/src/App.tsx
+++ b/hacker-news-jobs/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs: Array<chrome.tabs.Tab>) => {
         HackerNews.getLatestJobsPage()
           .then((jobsUrl: string) => {
-            if (tabs.length > 0 && tabs[0].url === jobsUrl) {
+            if (tabs.length > 0 && tabs[0].url && tabs[0].url.includes(jobsUrl)) {
               return Promise.resolve(tabs[0]);
             }
 

--- a/hacker-news-jobs/src/chrome/content.ts
+++ b/hacker-news-jobs/src/chrome/content.ts
@@ -1,7 +1,10 @@
 import { ChromeMessage, MessageType } from "../types";
-import HackerNews from './hn-api';
+import HackerNews, { HackerNewsItem } from './hn-api';
 import jobPostingsSorter from './job-postings';
 import { bm25Search } from './bm25-search';
+
+
+let comments: Promise<(HackerNewsItem | null)[]>;
 
 
 async function getKidIdsFromStory(storyId: number): Promise<number[] | null> {
@@ -16,6 +19,10 @@ async function getKidIdsFromStory(storyId: number): Promise<number[] | null> {
 }
 
 async function getComments(storyId: number, truncate: boolean, lastJobId: number) {
+    if (comments) {
+        return comments;
+    }
+
     return getKidIdsFromStory(storyId)
         .then(async (kidIds: number[] | null) => {
             if (!kidIds) {
@@ -32,7 +39,8 @@ async function getComments(storyId: number, truncate: boolean, lastJobId: number
                 }
             }
 
-            return await Promise.all(all);
+            comments = Promise.all(all);
+            return await comments;
         });
 }
 

--- a/hacker-news-jobs/src/chrome/job-postings.ts
+++ b/hacker-news-jobs/src/chrome/job-postings.ts
@@ -12,9 +12,17 @@ class JobPostingsSorter {
   postingsTable: HTMLTableElement;
   originalPostings: Array<HTMLTableRowElement>;
   rowsById: JobPostingsById;
+  lastRowId: number;
 
   constructor() {
     this.postingsTable = document.querySelector('table.comment-tree') as HTMLTableElement;
+    this.originalPostings = [];
+    this.rowsById = {};
+    this.lastRowId = 0;
+    if (!this.postingsTable) {
+      return;
+    }
+
     this.originalPostings = []
     this.rowsById = this.getRowsById();
     const currentTBody = this.postingsTable.querySelector('tbody') as HTMLTableSectionElement;
@@ -60,7 +68,7 @@ class JobPostingsSorter {
 
     // Create a map of postings by id along with their children to lookup postings easily
     const rowsById: JobPostingsById = {};
-    let currentParentId: number;
+    let currentParentId: number = 0;
     tableRows.forEach((row) => {
       const postingId = parseInt(row.id, 10);
       const indentElement = row.querySelector('td.ind') as HTMLTableCellElement;
@@ -81,6 +89,7 @@ class JobPostingsSorter {
       }
     });
 
+    this.lastRowId = currentParentId;
     return rowsById;
   }
 

--- a/hacker-news-jobs/src/chrome/job-postings.ts
+++ b/hacker-news-jobs/src/chrome/job-postings.ts
@@ -12,13 +12,11 @@ class JobPostingsSorter {
   postingsTable: HTMLTableElement;
   originalPostings: Array<HTMLTableRowElement>;
   rowsById: JobPostingsById;
-  lastRowId: number;
 
   constructor() {
     this.postingsTable = document.querySelector('table.comment-tree') as HTMLTableElement;
     this.originalPostings = [];
     this.rowsById = {};
-    this.lastRowId = 0;
     if (!this.postingsTable) {
       return;
     }
@@ -68,7 +66,7 @@ class JobPostingsSorter {
 
     // Create a map of postings by id along with their children to lookup postings easily
     const rowsById: JobPostingsById = {};
-    let currentParentId: number = 0;
+    let currentParentId: number;
     tableRows.forEach((row) => {
       const postingId = parseInt(row.id, 10);
       const indentElement = row.querySelector('td.ind') as HTMLTableCellElement;
@@ -89,7 +87,6 @@ class JobPostingsSorter {
       }
     });
 
-    this.lastRowId = currentParentId;
     return rowsById;
   }
 

--- a/hacker-news-jobs/src/chrome/job-postings.ts
+++ b/hacker-news-jobs/src/chrome/job-postings.ts
@@ -4,6 +4,7 @@
 interface JobPostingsById {
   [key: number]: {
     row: HTMLTableRowElement,
+    originalOrder: number,
     children: Array<HTMLTableRowElement>
   }
 };
@@ -67,6 +68,7 @@ class JobPostingsSorter {
     // Create a map of postings by id along with their children to lookup postings easily
     const rowsById: JobPostingsById = {};
     let currentParentId: number;
+    let originalOrder: number = 1;
     tableRows.forEach((row) => {
       const postingId = parseInt(row.id, 10);
       const indentElement = row.querySelector('td.ind') as HTMLTableCellElement;
@@ -78,8 +80,11 @@ class JobPostingsSorter {
       if (!rowsById[postingId]) {
         rowsById[postingId] = {
           row: row,
+          originalOrder: originalOrder,
           children: []
         }
+
+        originalOrder++;
       }
 
       if (!isParent) {
@@ -102,18 +107,27 @@ class JobPostingsSorter {
     oldTBody.remove();
 
     // Create sorted list of displayed postings
-    rankedJobIds.forEach((postingId) => {
+    console.log('Ranked output from search')
+    rankedJobIds.forEach((postingId, i) => {
       if (!this.rowsById[postingId]) {
         return;
       }
 
-      sortedRows.push(this.rowsById[postingId].row);
-      this.rowsById[postingId].children.forEach((childPost) => {
+      const { originalOrder, row, children } = this.rowsById[postingId];
+      const comment = row.querySelector('.comment');
+      const content = comment && comment.textContent?.trim();
+      sortedRows.push(row);
+      console.log({
+        postId: postingId,
+        originalOrder: originalOrder,
+        newOrder: i + 1,
+        text: content
+      });
+
+      children.forEach((childPost) => {
         sortedRows.push(childPost);
       });
     });
-
-    console.log(sortedRows);
 
     // Insert new tbody with sorted rows into DOM
     newTBody.append(...sortedRows);


### PR DESCRIPTION
This improves performance by caching the postings fetch and also just fetching what is on the page. So, that is ~250 calls instead of ~1K calls. The actual NLP engine loading doesn't seem to take that long.  I also think the engine is not being cached right now.  But that doesn't make much of a difference. Could also just make this even faster by not even fetching from the API.

Also, updated to allow searching on subsequent pages.  Still have to click on the "more posts" link at the end though. 